### PR TITLE
LGK-16880: Add configurable products to cart

### DIFF
--- a/Api/AddToCartInterface.php
+++ b/Api/AddToCartInterface.php
@@ -1,8 +1,6 @@
 <?php
 namespace Logik\Logik\Api;
 
-use Magento\Quote\Api\Data\CartItemInterface;
-
 interface AddToCartInterface
 {
 /**

--- a/Model/AddToCart.php
+++ b/Model/AddToCart.php
@@ -1,7 +1,7 @@
 <?php
-namespace Logik\AddToCart\Model;
+namespace Logik\Logik\Model;
 
-use Logik\AddToCart\Api\AddToCartInterface;
+use Logik\Logik\Api\AddToCartInterface;
 use Magento\Quote\Api\CartRepositoryInterface;
 use Magento\Catalog\Api\ProductRepositoryInterface;
 use Magento\ConfigurableProduct\Model\ResourceModel\Product\Type\Configurable;

--- a/Model/AddToCart.php
+++ b/Model/AddToCart.php
@@ -6,14 +6,13 @@ use Magento\Quote\Api\CartRepositoryInterface;
 use Magento\Catalog\Api\ProductRepositoryInterface;
 use Magento\ConfigurableProduct\Model\ResourceModel\Product\Type\Configurable;
 use Psr\Log\LoggerInterface;
-use function PHPUnit\Framework\isNull;
 
 class AddToCart implements AddToCartInterface
 {
-    protected $cartRepository;
-    protected $logger;
-    protected $productRepository;
-    protected $configurable;
+    private $cartRepository;
+    private $logger;
+    private $productRepository;
+    private $configurable;
 
     public function __construct(
         CartRepositoryInterface $cartRepository,
@@ -76,10 +75,6 @@ class AddToCart implements AddToCartInterface
                     $quoteItem->setPrice($price);
                     $quoteItem->getProduct()->setIsSuperMode(true);
                 }
-                // This ensures that calls to get the cart will have the custom price
-                $quote->collectTotals();
-                // Save the quote
-                $this->cartRepository->save($quote);
             } catch (\Exception $e) {
                 $this->logger->error($e->getMessage());
                 $errors[] = [
@@ -94,6 +89,10 @@ class AddToCart implements AddToCartInterface
                 ];  
             } 
         }
+        // This ensures that calls to get the cart will have the custom price
+        $quote->collectTotals();
+        // Save the quote
+        $this->cartRepository->save($quote);
         return $errors;
     }
 

--- a/etc/acl.xml
+++ b/etc/acl.xml
@@ -6,8 +6,12 @@
                 <resource id="Magento_Backend::stores">
                     <resource id="Logik_Logik::logik" title="Logik" sortOrder="50">
                         <resource id="Logik_Logik::logik_settingspage" title="Credentials" sortOrder="10"/>
+                        <resource id="Logik_Logik::add_to_cart" title="Logik Add to Cart" sortOrder="20" />
                     </resource>
                 </resource>
+                <!-- <resource id="Magento_Cart::manage">
+                    <resource id="Logik_Logik::add_to_cart" title="Logik Add to Cart" sortOrder="10" />
+                </resource> -->
             </resource>
         </resources>
     </acl>

--- a/etc/acl.xml
+++ b/etc/acl.xml
@@ -9,9 +9,6 @@
                         <resource id="Logik_Logik::add_to_cart" title="Logik Add to Cart" sortOrder="20" />
                     </resource>
                 </resource>
-                <!-- <resource id="Magento_Cart::manage">
-                    <resource id="Logik_Logik::add_to_cart" title="Logik Add to Cart" sortOrder="10" />
-                </resource> -->
             </resource>
         </resources>
     </acl>

--- a/etc/adminhtml/menu.xml
+++ b/etc/adminhtml/menu.xml
@@ -3,7 +3,7 @@
     <menu>
         <add id="Logik_Logik::logik" title="Logik" translate="title" module="Logik_Logik" sortOrder="50" parent="Magento_Backend::stores" resource="Logik_Logik::logik"/>
         <add id="Logik_Logik::logik_settingspage" title="Credentials" translate="title" module="Logik_Logik" sortOrder="10" parent="Logik_Logik::logik" action="logiksettings/settingspage" resource="Logik_Logik::logik_settingspage"/>
-        <add id="Logik_Logik::add_to_cart" title="Logik Add to Cart" translate="title" module="Logik_Logik" parent="Logik_Logik::logik" resource="Logik_Logik::add_to_cart">
+        <add id="Logik_Logik::add_to_cart" title="Logik Add to Cart" translate="title" module="Logik_Logik" parent="Logik_Logik::logik" resource="Logik_Logik::add_to_cart"/>
 
     </menu>
 </config>

--- a/etc/adminhtml/menu.xml
+++ b/etc/adminhtml/menu.xml
@@ -3,5 +3,7 @@
     <menu>
         <add id="Logik_Logik::logik" title="Logik" translate="title" module="Logik_Logik" sortOrder="50" parent="Magento_Backend::stores" resource="Logik_Logik::logik"/>
         <add id="Logik_Logik::logik_settingspage" title="Credentials" translate="title" module="Logik_Logik" sortOrder="10" parent="Logik_Logik::logik" action="logiksettings/settingspage" resource="Logik_Logik::logik_settingspage"/>
+        <add id="Logik_Logik::add_to_cart" title="Logik Add to Cart" translate="title" module="Logik_Logik" parent="Logik_Logik::logik" resource="Logik_Logik::add_to_cart">
+
     </menu>
 </config>

--- a/etc/adminhtml/menu.xml
+++ b/etc/adminhtml/menu.xml
@@ -3,7 +3,5 @@
     <menu>
         <add id="Logik_Logik::logik" title="Logik" translate="title" module="Logik_Logik" sortOrder="50" parent="Magento_Backend::stores" resource="Logik_Logik::logik"/>
         <add id="Logik_Logik::logik_settingspage" title="Credentials" translate="title" module="Logik_Logik" sortOrder="10" parent="Logik_Logik::logik" action="logiksettings/settingspage" resource="Logik_Logik::logik_settingspage"/>
-        <add id="Logik_Logik::add_to_cart" title="Logik Add to Cart" translate="title" module="Logik_Logik" parent="Logik_Logik::logik" resource="Logik_Logik::add_to_cart"/>
-
     </menu>
 </config>

--- a/etc/webapi.xml
+++ b/etc/webapi.xml
@@ -3,7 +3,7 @@
     <route url="/V1/logik/carts/:quoteId" method="POST">
         <service class="Logik\Logik\Api\AddToCartInterface" method="addItems"/>
         <resources>
-            <resource ref="Magento_Cart::manage"/>
+            <resource ref="Logik_Logik::add_to_cart"/>
         </resources>
     </route>
 </routes>


### PR DESCRIPTION
This PR makes it so that passing a sku, that is a child of a configurable product, will add that product as a configurable product with the appropriate options. This also addresses some of the changes requested by Hero. I removed the unused imports, and updated the permission to use a custom permission for add to cart - this prevents the token from needing access to all cart endpoints.  
*Note: we expect there to be only one parent product - if there are more than one configurable parent for the given sku, we will use the first in the returned array