### PR TITLE
Renaming module to Logik_Integraiton

### DIFF
--- a/Block/Adminhtml/Form/Field/IntegrationToken.php
+++ b/Block/Adminhtml/Form/Field/IntegrationToken.php
@@ -18,7 +18,7 @@ class IntegrationToken extends Field
                     readonly="readonly">';
         $html .= '<button type="button" 
                     class="action-default scalable toggle-token" 
-                    data-mage-init=\'{"Logik_Logik/js/toggle-token": {}}\'>
+                    data-mage-init=\'{"Logik_Integration/js/toggle-token": {}}\'>
                     <span>Show Token</span>
                 </button>';
         $html .= '</div>';

--- a/Controller/Adminhtml/SettingsPage/Index.php
+++ b/Controller/Adminhtml/SettingsPage/Index.php
@@ -15,7 +15,7 @@ use Magento\Framework\View\Result\PageFactory;
 
 class Index extends Action implements HttpGetActionInterface
 {
-    const MENU_ID = 'Logik_Logik::logik_settingspage';
+    const MENU_ID = 'Logik_Integration::logik_settingspage';
 
     /**
      * @var PageFactory

--- a/Controller/Adminhtml/SettingsPage/Save.php
+++ b/Controller/Adminhtml/SettingsPage/Save.php
@@ -223,6 +223,6 @@ class Save extends Action
 
     protected function _isAllowed()
     {
-        return $this->_authorization->isAllowed('Logik_Logik::logik_settingspage');
+        return $this->_authorization->isAllowed('Logik_Integration::logik_settingspage');
     }
 }

--- a/Test/Integration/Controller/Adminhtml/SettingsPage/SaveTest.php
+++ b/Test/Integration/Controller/Adminhtml/SettingsPage/SaveTest.php
@@ -11,7 +11,7 @@ class SaveTest extends AbstractBackendController
     /**
      * @var string
      */
-    protected $resource = 'Logik_Logik::logik_settingspage';
+    protected $resource = 'Logik_Integration::logik_settingspage';
 
     /**
      * @var string

--- a/Test/Unit/Controller/Adminhtml/SettingsPage/SaveTest.php
+++ b/Test/Unit/Controller/Adminhtml/SettingsPage/SaveTest.php
@@ -73,7 +73,7 @@ class SaveTest extends TestCase
         $authorization = $this->createMock(\Magento\Framework\Authorization::class);
         $authorization->expects($this->once())
             ->method('isAllowed')
-            ->with('Logik_Logik::logik_settingspage')
+            ->with('Logik_Integration::logik_settingspage')
             ->willReturn(true);
         
         $context = $this->createMock(\Magento\Backend\App\Action\Context::class);

--- a/Test/Unit/phpunit.xml.dist
+++ b/Test/Unit/phpunit.xml.dist
@@ -13,7 +13,7 @@
         </exclude>
     </coverage>
     <testsuites>
-        <testsuite name="Logik_Logik Unit Tests">
+        <testsuite name="Logik_Integration Unit Tests">
             <directory suffix="Test.php">.</directory>
         </testsuite>
     </testsuites>

--- a/etc/acl.xml
+++ b/etc/acl.xml
@@ -4,9 +4,9 @@
         <resources>
             <resource id="Magento_Backend::admin">
                 <resource id="Magento_Backend::stores">
-                    <resource id="Logik_Logik::logik" title="Logik" sortOrder="50">
-                        <resource id="Logik_Logik::logik_settingspage" title="Credentials" sortOrder="10"/>
-                        <resource id="Logik_Logik::add_to_cart" title="Logik Add to Cart" sortOrder="20" />
+                    <resource id="Logik_Integration::logik" title="Logik" sortOrder="50">
+                        <resource id="Logik_Integration::logik_settingspage" title="Credentials" sortOrder="10"/>
+                        <resource id="Logik_Integration::add_to_cart" title="Logik Add to Cart" sortOrder="20" />
                     </resource>
                 </resource>
             </resource>

--- a/etc/adminhtml/menu.xml
+++ b/etc/adminhtml/menu.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Backend:etc/menu.xsd">
     <menu>
-        <add id="Logik_Logik::logik" title="Logik" translate="title" module="Logik_Logik" sortOrder="50" parent="Magento_Backend::stores" resource="Logik_Logik::logik"/>
-        <add id="Logik_Logik::logik_settingspage" title="Credentials" translate="title" module="Logik_Logik" sortOrder="10" parent="Logik_Logik::logik" action="logiksettings/settingspage" resource="Logik_Logik::logik_settingspage"/>
+        <add id="Logik_Integration::logik" title="Logik" translate="title" module="Logik_Integration" sortOrder="50" parent="Magento_Backend::stores" resource="Logik_Integration::logik"/>
+        <add id="Logik_Integration::logik_settingspage" title="Credentials" translate="title" module="Logik_Integration" sortOrder="10" parent="Logik_Integration::logik" action="logiksettings/settingspage" resource="Logik_Integration::logik_settingspage"/>
     </menu>
 </config>

--- a/etc/adminhtml/routes.xml
+++ b/etc/adminhtml/routes.xml
@@ -2,7 +2,7 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:App/etc/routes.xsd">
     <router id="admin">
         <route id="logiksettings" frontName="logiksettings">
-            <module name="Logik_Logik"/>
+            <module name="Logik_Integration"/>
         </route>
     </router>
 </config>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -7,7 +7,7 @@
         <section id="logik_settings" translate="label" type="text" sortOrder="110" showInDefault="1" showInWebsite="1" showInStore="1">
             <label>Logik Settings</label>
             <tab>logik</tab>
-            <resource>Logik_Logik::config</resource>
+            <resource>Logik_Integration::config</resource>
             <group id="general" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>General Configuration</label>
                 <field id="logik_url" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Logik_AdminConfig" setup_version="1.0.0">
+    <module name="Logik_Integration" setup_version="1.0.0">
         <sequence>
             <module name="Magento_Backend"/>
         </sequence>

--- a/etc/webapi.xml
+++ b/etc/webapi.xml
@@ -3,7 +3,7 @@
     <route url="/V1/logik/carts/:quoteId" method="POST">
         <service class="Logik\Logik\Api\AddToCartInterface" method="addItems"/>
         <resources>
-            <resource ref="Logik_Logik::add_to_cart"/>
+            <resource ref="Logik_Integration::add_to_cart"/>
         </resources>
     </route>
 </routes>

--- a/registration.php
+++ b/registration.php
@@ -8,6 +8,6 @@ use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(
     ComponentRegistrar::MODULE,
-    'Logik_Logik',
+    'Logik_Integration',
     __DIR__
 );

--- a/view/adminhtml/layout/adminhtml_system_config_edit.xml
+++ b/view/adminhtml/layout/adminhtml_system_config_edit.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0"?>
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <head>
-        <css src="Logik_Logik::css/styles.css"/>
+        <css src="Logik_Integration::css/styles.css"/>
     </head>
     <body>
         <referenceContainer name="js">
-            <block class="Magento\Backend\Block\Template" template="Logik_Logik::js.phtml"/>
+            <block class="Magento\Backend\Block\Template" template="Logik_Integration::js.phtml"/>
         </referenceContainer>
     </body>
 </page> 

--- a/view/adminhtml/layout/logiksettings_settingspage_index.xml
+++ b/view/adminhtml/layout/logiksettings_settingspage_index.xml
@@ -2,21 +2,21 @@
 <!-- Debug: Layout file loaded -->
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <head>
-        <css src="Logik_Logik::css/styles.css"/>
+        <css src="Logik_Integration::css/styles.css"/>
     </head>
     <body>
         <referenceContainer name="content">
             <block class="Logik\Logik\Block\Adminhtml\SettingsPage" 
                    name="logik_settings_page" 
-                   template="Logik_Logik::settingspage.phtml"/>
+                   template="Logik_Integration::settingspage.phtml"/>
         </referenceContainer>
         <referenceContainer name="js">
             <block class="Magento\Backend\Block\Template" 
-                   template="Logik_Logik::js.phtml"/>
+                   template="Logik_Integration::js.phtml"/>
         </referenceContainer>
         <referenceContainer name="before.body.end">
             <block class="Magento\Backend\Block\Template" 
-                   template="Logik_Logik::form-validation.phtml"/>
+                   template="Logik_Integration::form-validation.phtml"/>
         </referenceContainer>
     </body>
 </page>

--- a/view/adminhtml/requirejs-config.js
+++ b/view/adminhtml/requirejs-config.js
@@ -1,9 +1,9 @@
 var config = {
     map: {
         '*': {
-            'Logik_Logik/js/toggle-token': 'Logik_Logik/js/toggle-token',
-            'Logik_Logik/js/test-credentials': 'Logik_Logik/js/test-credentials',
-            'Logik_Logik/js/form-validation': 'Logik_Logik/js/form-validation'
+            'Logik_Integration/js/toggle-token': 'Logik_Integration/js/toggle-token',
+            'Logik_Integration/js/test-credentials': 'Logik_Integration/js/test-credentials',
+            'Logik_Integration/js/form-validation': 'Logik_Integration/js/form-validation'
         }
     },
     deps: [

--- a/view/adminhtml/templates/form-validation.phtml
+++ b/view/adminhtml/templates/form-validation.phtml
@@ -1,6 +1,6 @@
 <script>
     require([
-        'Logik_Logik/js/form-validation'
+        'Logik_Integration/js/form-validation'
     ], function (FormValidation) {
         FormValidation();
     });

--- a/view/adminhtml/templates/js.phtml
+++ b/view/adminhtml/templates/js.phtml
@@ -1,7 +1,7 @@
 <script type="text/x-magento-init">
 {
     "*": {
-        "Logik_Logik/js/toggle-token": {}
+        "Logik_Integration/js/toggle-token": {}
     }
 }
 </script> 

--- a/view/adminhtml/templates/settingspage.phtml
+++ b/view/adminhtml/templates/settingspage.phtml
@@ -42,7 +42,7 @@ $logger->info('Template file settingspage.phtml loaded');
                    readonly="readonly">
             <button type="button" 
                     class="action-default scalable toggle-token" 
-                    data-mage-init='{"Logik_Logik/js/toggle-token": {}}'>
+                    data-mage-init='{"Logik_Integration/js/toggle-token": {}}'>
                 <span>Show Token</span>
             </button>
         </div>
@@ -54,7 +54,7 @@ $logger->info('Template file settingspage.phtml loaded');
         <button type="button" 
                 id="test-credentials" 
                 class="action secondary"
-                data-mage-init='{"Logik_Logik/js/test-credentials": {}}'>
+                data-mage-init='{"Logik_Integration/js/test-credentials": {}}'>
             <span>Test Credentials</span>
         </button>
     </div>


### PR DESCRIPTION
This replaces all references to the module name with Logik_Integration. Tokens will need to be regenerated, but otherwise no functional changes should occur.