### PR TITLE
LGK-17188: Ensure swagger is functional with custom API

### DIFF
--- a/Api/AddToCartInterface.php
+++ b/Api/AddToCartInterface.php
@@ -1,6 +1,10 @@
 <?php
 namespace Logik\Integration\Api;
 
+/**
+ * Add to cart interface
+ * @api
+ */
 interface AddToCartInterface
 {
 /**
@@ -10,5 +14,5 @@ interface AddToCartInterface
  * @param \Magento\Quote\Api\Data\CartItemInterface[] $items
  * @return \Logik\Integration\Api\Data\ProductFailMessageInterface[] List of errors keyed by SKU
  */
-    public function addItems(int $quoteId, array $items): array;
+    public function addItems(int $quoteId, array $items);
 }

--- a/Api/AddToCartInterface.php
+++ b/Api/AddToCartInterface.php
@@ -1,10 +1,6 @@
 <?php
 namespace Logik\Integration\Api;
 
-/**
- * Add to cart interface
- * @api
- */
 interface AddToCartInterface
 {
 /**

--- a/Api/AddToCartInterface.php
+++ b/Api/AddToCartInterface.php
@@ -8,7 +8,7 @@ interface AddToCartInterface
  *
  * @param int $quoteId
  * @param \Magento\Quote\Api\Data\CartItemInterface[] $items
- * @return array List of errors keyed by SKU
+ * @return \Logik\Integration\Api\Data\ProductFailMessageInterface[] List of errors keyed by SKU
  */
     public function addItems(int $quoteId, array $items): array;
 }

--- a/Api/Data/ProductFailMessageInterface.php
+++ b/Api/Data/ProductFailMessageInterface.php
@@ -1,0 +1,34 @@
+<?php
+namespace Logik\Integration\Api\Data;
+
+interface ProductFailMessageInterface {
+        /**
+     * Get SKU
+     *
+     * @return string
+     */
+    public function getSku();
+
+    /**
+     * Set SKU
+     *
+     * @param string $sku
+     * @return $this
+     */
+    public function setSku($sku);
+
+    /**
+     * Get message
+     *
+     * @return string
+     */
+    public function getMessage();
+
+    /**
+     * Set message
+     *
+     * @param string $message
+     * @return $this
+     */
+    public function setMessage($message);
+}

--- a/Api/Data/ProductFailMessageInterface.php
+++ b/Api/Data/ProductFailMessageInterface.php
@@ -2,7 +2,15 @@
 namespace Logik\Integration\Api\Data;
 
 interface ProductFailMessageInterface {
-        /**
+
+    /**
+     * Summary of __construct
+     * @param string $sku
+     * @param string $message
+     */
+    public function __construct($sku, $message);
+
+    /**
      * Get SKU
      *
      * @return string

--- a/Api/Data/ProductFailMessageInterface.php
+++ b/Api/Data/ProductFailMessageInterface.php
@@ -1,7 +1,8 @@
 <?php
 namespace Logik\Integration\Api\Data;
 
-interface ProductFailMessageInterface {
+interface ProductFailMessageInterface
+{
 
     /**
      * Summary of __construct

--- a/Exception/LogikCartException.php
+++ b/Exception/LogikCartException.php
@@ -8,12 +8,17 @@ use Logik\Integration\Api\Data\ProductFailMessageInterface;
 
 class LogikCartException extends AbstractAggregateException
 {
+    /**
+     * Summary of errors
+     *
+     * @var LocalizedException[]
+     */
     protected $errors;
 
     /** Construct an exception containing all failed products
-     * @param string $message Top level message
+     * @param string                         $message Top level message
      * @param ProductFailMessageInterface[]  $errors  Array of errors containing problem SKU and its message
-     * @param int    $code    Error code, default: 400
+     * @param int                            $code    Error code, default: 400
      */
     public function __construct($message, array $errors = [], $code = 400)
     {
@@ -36,7 +41,8 @@ class LogikCartException extends AbstractAggregateException
 
     /**
      * Get Errors attached to this exception, used by exception handlers
-     * @return [] array of LocalizedException
+     *
+     * @return LocalizedException[]
      */
     public function getErrors()
     {

--- a/Exception/LogikCartException.php
+++ b/Exception/LogikCartException.php
@@ -4,6 +4,7 @@ namespace Logik\Integration\Exception;
 use Magento\Framework\Exception\AbstractAggregateException;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Phrase;
+use Logik\Integration\Api\Data\ProductFailMessageInterface;
 
 class LogikCartException extends AbstractAggregateException
 {
@@ -11,7 +12,7 @@ class LogikCartException extends AbstractAggregateException
 
     /** Construct an exception containing all failed products
      * @param string $message Top level message
-     * @param array  $errors  Array of errors containing problem SKU and its message
+     * @param ProductFailMessageInterface[]  $errors  Array of errors containing problem SKU and its message
      * @param int    $code    Error code, default: 400
      */
     public function __construct($message, array $errors = [], $code = 400)
@@ -27,7 +28,7 @@ class LogikCartException extends AbstractAggregateException
             $this->errors[] = new LocalizedException(
                 new Phrase(
                     "An error occurred adding item %1 to cart %2",
-                    [$error['sku'], $error['message']]
+                    [$error->getSku(), $error->getMessage()]
                 )
             );
         }

--- a/Model/AddToCart.php
+++ b/Model/AddToCart.php
@@ -39,7 +39,7 @@ class AddToCart implements AddToCartInterface
      *
      * @param int $quoteId
      * @param \Magento\Quote\Api\Data\CartItemInterface[] $items
-     * @return array List of errors keyed by SKU
+     * @return \Logik\Integration\Api\Data\ProductFailMessageInterface[] List of errors keyed by SKU
      */
     public function addItems(int $quoteId, array $items): array
     {
@@ -224,7 +224,7 @@ class AddToCart implements AddToCartInterface
         if (is_string($quoteItem)) {
             throw new LocalizedException(__("Failed to add product to quote: %1", $quoteItem));
         }
-
+        print_r("Here");
         // Set custom prices on children
         foreach ($quoteItem->getChildren() as $childItem) {
             $data = $bundleItemData[$childItem->getSku()];

--- a/Model/AddToCart.php
+++ b/Model/AddToCart.php
@@ -3,15 +3,15 @@ namespace Logik\Integration\Model;
 
 use Logik\Integration\Api\AddToCartInterface;
 use Logik\Integration\Exception\LogikCartException;
+use Logik\Integration\Model\Data\ProductFailMessage;
 use Magento\Framework\Exception\LocalizedException;
-use Magento\Quote\Api\CartRepositoryInterface;
 use Magento\Catalog\Api\ProductRepositoryInterface;
-use Magento\ConfigurableProduct\Model\ResourceModel\Product\Type\Configurable;
 use Magento\Catalog\Model\Product\Type;
+use Magento\ConfigurableProduct\Model\ResourceModel\Product\Type\Configurable;
+use Magento\Bundle\Model\ResourceModel\Selection\CollectionFactory as SelectionCollectionFactory;
+use Magento\Quote\Api\CartRepositoryInterface;
 use Magento\Framework\DataObject;
 use Psr\Log\LoggerInterface;
-use Magento\Bundle\Model\ResourceModel\Selection\CollectionFactory as SelectionCollectionFactory;
-use Logik\Integration\Model\ProductFailMessage;
 
 class AddToCart implements AddToCartInterface
 {

--- a/Model/AddToCart.php
+++ b/Model/AddToCart.php
@@ -21,6 +21,14 @@ class AddToCart implements AddToCartInterface
     private $configurable;
     private $selectionCollectionFactory;
 
+    /**
+     * Summary of __construct
+     * @param \Magento\Quote\Api\CartRepositoryInterface $cartRepository
+     * @param \Psr\Log\LoggerInterface $logger
+     * @param \Magento\Catalog\Api\ProductRepositoryInterface $productRepository
+     * @param \Magento\ConfigurableProduct\Model\ResourceModel\Product\Type\Configurable $configurable
+     * @param \Magento\Bundle\Model\ResourceModel\Selection\CollectionFactory $selectionCollectionFactory
+     */
     public function __construct(
         CartRepositoryInterface $cartRepository,
         LoggerInterface $logger,
@@ -56,7 +64,9 @@ class AddToCart implements AddToCartInterface
                 // Get Custom Options array
                 $options = [];
                 $bundleOptions = [];
-                if ($item->getProductOption() !== null && $item->getProductOption()->getExtensionAttributes() !== null) {
+                $productOption = $item->getProductOption();
+                if ($productOption !== null && $productOption->getExtensionAttributes() !== null) {
+                    
                     foreach ($item->getProductOption()->getExtensionAttributes()->getCustomOptions() as $customOption) {
                         $options[$customOption->getOptionId()] = $customOption->getOptionValue();
                         if ($customOption->getOptionId() === "bundle_options") {
@@ -85,7 +95,9 @@ class AddToCart implements AddToCartInterface
                 if (!($quoteItem instanceof \Magento\Quote\Model\Quote\Item)) {
                     // This syntax is kinda ridiculous - why does this append to an array
                     $errors[] = new ProductFailMessage(
-                        $sku, 'Failed to add product to quote with message ' . $quoteItem);
+                        $sku,
+                        'Failed to add product to quote with message ' . $quoteItem
+                    );
                     continue;
                 }
                 // If we have a price, set it and ensure it will be used

--- a/Model/AddToCart.php
+++ b/Model/AddToCart.php
@@ -11,6 +11,7 @@ use Magento\Catalog\Model\Product\Type;
 use Magento\Framework\DataObject;
 use Psr\Log\LoggerInterface;
 use Magento\Bundle\Model\ResourceModel\Selection\CollectionFactory as SelectionCollectionFactory;
+use Logik\Integration\Model\ProductFailMessage;
 
 class AddToCart implements AddToCartInterface
 {
@@ -83,10 +84,8 @@ class AddToCart implements AddToCartInterface
                 // Handle errors adding product
                 if (!($quoteItem instanceof \Magento\Quote\Model\Quote\Item)) {
                     // This syntax is kinda ridiculous - why does this append to an array
-                    $errors[] = [
-                        'sku' => $sku,
-                        'message' => 'Failed to add product to quote with message ' . $quoteItem
-                    ];
+                    $errors[] = new ProductFailMessage(
+                        $sku, 'Failed to add product to quote with message ' . $quoteItem);
                     continue;
                 }
                 // If we have a price, set it and ensure it will be used
@@ -99,16 +98,10 @@ class AddToCart implements AddToCartInterface
                 }
             } catch (\Exception $e) {
                 $this->logger->error($e->getMessage());
-                $errors[] = [
-                    'sku' => $item->getSku(),
-                    'message' => $e->getMessage()
-                ];
+                $errors[] = new ProductFailMessage($item->getSku(), $e->getMessage());
             } catch (\Error $error) {
                 $this->logger->error($error->getMessage());
-                $errors[] = [
-                    'sku' => $item->getSku(),
-                    'message' => $error->getMessage()
-                ];
+                $errors[] = new ProductFailMessage($item->getSku(), $error->getMessage());
             }
         }
         // If all items failed

--- a/Model/AddToCart.php
+++ b/Model/AddToCart.php
@@ -217,7 +217,6 @@ class AddToCart implements AddToCartInterface
         if (is_string($quoteItem)) {
             throw new LocalizedException(__("Failed to add product to quote: %1", $quoteItem));
         }
-        print_r("Here");
         // Set custom prices on children
         foreach ($quoteItem->getChildren() as $childItem) {
             $data = $bundleItemData[$childItem->getSku()];

--- a/Model/Data/ProductFailMessage.php
+++ b/Model/Data/ProductFailMessage.php
@@ -1,0 +1,39 @@
+<?php
+namespace Logik\Integration\Model;
+
+use Logik\Integration\Api\Data\ProductFailMessageInterface;
+
+class ProductFailMessage implements ProductFailMessageInterface
+{
+    /**
+     * @var string
+     */
+    protected $sku;
+
+    /**
+     * @var string
+     */
+    protected $message;
+
+    public function getSku()
+    {
+        return $this->sku;
+    }
+
+    public function setSku($sku)
+    {
+        $this->sku = $sku;
+        return $this;
+    }
+
+    public function getMessage()
+    {
+        return $this->message;
+    }
+
+    public function setMessage($message)
+    {
+        $this->message = $message;
+        return $this;
+    }
+}

--- a/Model/Data/ProductFailMessage.php
+++ b/Model/Data/ProductFailMessage.php
@@ -15,22 +15,45 @@ class ProductFailMessage implements ProductFailMessageInterface
      */
     protected $message;
 
+    public function __construct($sku, $message) {
+        $this->sku = $sku;
+        $this->message = $message;
+    }
+
+    /**
+     * Summary of getSku
+     * @return string
+     */
     public function getSku()
     {
         return $this->sku;
     }
 
+    /**
+     * Summary of setSku
+     * @param string $sku
+     * @return static
+     */
     public function setSku($sku)
     {
         $this->sku = $sku;
         return $this;
     }
 
+    /**
+     * Summary of getMessage
+     * @return string
+     */
     public function getMessage()
     {
         return $this->message;
     }
 
+    /**
+     * Summary of setMessage
+     * @param string $message
+     * @return static
+     */
     public function setMessage($message)
     {
         $this->message = $message;

--- a/Model/Data/ProductFailMessage.php
+++ b/Model/Data/ProductFailMessage.php
@@ -1,5 +1,5 @@
 <?php
-namespace Logik\Integration\Model;
+namespace Logik\Integration\Model\Data;
 
 use Logik\Integration\Api\Data\ProductFailMessageInterface;
 

--- a/Model/Data/ProductFailMessage.php
+++ b/Model/Data/ProductFailMessage.php
@@ -15,13 +15,22 @@ class ProductFailMessage implements ProductFailMessageInterface
      */
     protected $message;
 
-    public function __construct($sku, $message) {
+    /**
+     * Builds error information
+     *
+     * @param string $sku
+     * @param string $message
+     */
+
+    public function __construct($sku, $message)
+    {
         $this->sku = $sku;
         $this->message = $message;
     }
 
     /**
      * Summary of getSku
+     *
      * @return string
      */
     public function getSku()
@@ -31,6 +40,7 @@ class ProductFailMessage implements ProductFailMessageInterface
 
     /**
      * Summary of setSku
+     *
      * @param string $sku
      * @return static
      */
@@ -42,6 +52,7 @@ class ProductFailMessage implements ProductFailMessageInterface
 
     /**
      * Summary of getMessage
+     *
      * @return string
      */
     public function getMessage()
@@ -51,6 +62,7 @@ class ProductFailMessage implements ProductFailMessageInterface
 
     /**
      * Summary of setMessage
+     *
      * @param string $message
      * @return static
      */


### PR DESCRIPTION
This adds a data class for the error structure I was returning previously. Without this opening the /swagger page would give an error. Additionally I added a bunch of docstrings that phpcs was complaining about.